### PR TITLE
Fixed alerts creation on prometheus metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
-### NEXT_VERSION_TYPE=MAJOR|MINOR|PATCH
+### NEXT_VERSION_TYPE=MINOR
 ### NEXT_VERSION_DESCRIPTION_BEGIN
+* Added `referenceId`, `hidden` optional parameters to `MetricsBuilder.prometheusMetric`.
+* Parameter `metric` in `AlertQuery` is now optional.
+* Added method `query(metricId, duration)` to `ConditionBuilder`.
 ### NEXT_VERSION_DESCRIPTION_END
 ## [3.6.0](https://github.com/yoomoney/grafana-dashboard-dsl/pull/16) (01-09-2021)
 

--- a/src/main/kotlin/ru/yoomoney/tech/grafana/dsl/metrics/MetricsBuilder.kt
+++ b/src/main/kotlin/ru/yoomoney/tech/grafana/dsl/metrics/MetricsBuilder.kt
@@ -5,7 +5,6 @@ import ru.yoomoney.tech.grafana.dsl.datasource.Datasource
 import ru.yoomoney.tech.grafana.dsl.datasource.Zabbix
 import ru.yoomoney.tech.grafana.dsl.metrics.functions.Alias
 import ru.yoomoney.tech.grafana.dsl.metrics.prometheus.PrometheusMetric
-import ru.yoomoney.tech.grafana.dsl.metrics.prometheus.asPrometheusMetric
 import ru.yoomoney.tech.grafana.dsl.panels.graph.display.seriesoverrides.SeriesOverride
 import ru.yoomoney.tech.grafana.dsl.panels.graph.display.seriesoverrides.SeriesOverrideBuilder
 
@@ -20,8 +19,14 @@ class MetricsBuilder<DatasourceT : Datasource> {
         metrics += ReferencedDashboardMetric(fn(), referenceId ?: generateMetricId(), hidden)
     }
 
-    fun prometheusMetric(legendFormat: String? = null, instant: Boolean = false, fn: () -> PrometheusMetric) {
-        metrics += PromQlMetric(fn(), legendFormat, instant)
+    fun prometheusMetric(
+        legendFormat: String? = null,
+        instant: Boolean = false,
+        referenceId: String? = null,
+        hidden: Boolean = false,
+        fn: () -> PrometheusMetric
+    ) {
+        metrics += PromQlMetric(fn(), legendFormat, instant, referenceId ?: generateMetricId(), hidden)
     }
 
     private fun generateMetricId(): String {

--- a/src/main/kotlin/ru/yoomoney/tech/grafana/dsl/metrics/PromQlMetric.kt
+++ b/src/main/kotlin/ru/yoomoney/tech/grafana/dsl/metrics/PromQlMetric.kt
@@ -12,10 +12,14 @@ import ru.yoomoney.tech.grafana.dsl.metrics.prometheus.PrometheusMetric
 class PromQlMetric (
     val metric: PrometheusMetric,
     val legendFormat: String?,
-    val instant: Boolean
+    val instant: Boolean,
+    val id: String? = null,
+    val hidden: Boolean = false
 ) : DashboardMetric {
 
     override fun toJson() = jsonObject {
+        "refId" to id
+        "hide" to hidden
         "expr" to metric.asString()
         "format" to "time_series"
         "legendFormat" to legendFormat

--- a/src/main/kotlin/ru/yoomoney/tech/grafana/dsl/panels/alerting/AlertQuery.kt
+++ b/src/main/kotlin/ru/yoomoney/tech/grafana/dsl/panels/alerting/AlertQuery.kt
@@ -8,7 +8,7 @@ import ru.yoomoney.tech.grafana.dsl.metrics.DashboardMetric
 
 class AlertQuery(
     private val datasourceId: Long = 1,
-    private val metric: DashboardMetric,
+    private val metric: DashboardMetric? = null,
     private vararg val params: Any
 ) : Json<JSONObject> {
 
@@ -16,7 +16,9 @@ class AlertQuery(
         val json = JSONObject()
 
         json["datasourceId"] = datasourceId
-        json["model"] = metric.toJson()
+        if (metric != null) {
+            json["model"] = metric.toJson()
+        }
         json["params"] = JSONArray(params.toList())
 
         return json

--- a/src/main/kotlin/ru/yoomoney/tech/grafana/dsl/panels/alerting/ConditionBuilder.kt
+++ b/src/main/kotlin/ru/yoomoney/tech/grafana/dsl/panels/alerting/ConditionBuilder.kt
@@ -15,6 +15,10 @@ class ConditionBuilder {
             params = *arrayOf(metric.id, duration.toString(), now.toString())
     )
 
+    fun query(metricId: String, duration: Duration) = AlertQuery(
+        params = *arrayOf(metricId, duration.toString(), now.toString())
+    )
+
     infix fun AlertQuery.isAbove(value: Int) = QueryCondition(evaluator = AlertEvaluator("gt", value), query = this)
 
     fun sum(condition: AlertingCondition) = SumCondition(condition)

--- a/src/test/kotlin/ru/yoomoney/tech/grafana/dsl/metrics/MetricsBuilderTest.kt
+++ b/src/test/kotlin/ru/yoomoney/tech/grafana/dsl/metrics/MetricsBuilderTest.kt
@@ -54,6 +54,7 @@ class MetricsBuilderTest {
             "metric_name{}".asInstantVector()
         }
 
-        metricsBuilder.metrics[0].toJson().toString() shouldEqualToJson ("{\"format\":\"time_series\",\"expr\":\"metric_name{}\",\"instant\":true}")
+        metricsBuilder.metrics[0].toJson().toString() shouldEqualToJson
+                ("{\"format\":\"time_series\",\"expr\":\"metric_name{}\",\"instant\":true,\"refId\":\"A\",\"hide\":false}")
     }
 }

--- a/src/test/resources/ru/yoomoney/tech/grafana/dsl/panels/GraphPanelWithPrometheusDataSource.json
+++ b/src/test/resources/ru/yoomoney/tech/grafana/dsl/panels/GraphPanelWithPrometheusDataSource.json
@@ -37,6 +37,8 @@
   "type": "graph",
   "targets": [
     {
+      "refId": "A",
+      "hide": false,
       "format": "time_series",
       "legendFormat": "{{host}}",
       "expr": "jvm_classes_loaded_classes{app_name=\"example\"}",

--- a/src/test/resources/ru/yoomoney/tech/grafana/dsl/panels/MetricPanelWithPercentPrometheusMetric.json
+++ b/src/test/resources/ru/yoomoney/tech/grafana/dsl/panels/MetricPanelWithPercentPrometheusMetric.json
@@ -7,6 +7,8 @@
   "title": "Test Panel",
   "targets": [
     {
+      "refId": "A",
+      "hide": false,
       "format": "time_series",
       "legendFormat": "instance",
       "expr": "min by (instance) (jvm_memory_used_bytes{area=\"heap\"} / jvm_memory_max_bytes{area=\"heap\"})",

--- a/src/test/resources/ru/yoomoney/tech/grafana/dsl/panels/StatPanelWithPromQlMetric.json
+++ b/src/test/resources/ru/yoomoney/tech/grafana/dsl/panels/StatPanelWithPromQlMetric.json
@@ -34,6 +34,8 @@
   },
   "targets": [
     {
+      "refId": "A",
+      "hide": false,
       "format": "time_series",
       "legendFormat": "{{version}}",
       "expr": "app_info{app_name=\"my_app\",instance=\"host\"}",

--- a/src/test/resources/ru/yoomoney/tech/grafana/dsl/panels/table/TablePanelWithPrometheusMetrics.json
+++ b/src/test/resources/ru/yoomoney/tech/grafana/dsl/panels/table/TablePanelWithPrometheusMetrics.json
@@ -6,6 +6,8 @@
   "type": "table",
   "targets": [
     {
+      "refId": "A",
+      "hide": false,
       "format": "time_series",
       "legendFormat": "{{instance}}",
       "expr": "min by (instance) (jvm_memory_used_bytes{area=\"heap\"} / jvm_memory_max_bytes{area=\"heap\"})",


### PR DESCRIPTION
Added `referenceId`, `hidden` optional parameters to `MetricsBuilder.prometheusMetric`.
Parameter `metric` in `AlertQuery` is now optional.
Added method `query(metricId, duration)` to `ConditionBuilder`.